### PR TITLE
.gitignore commited to monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets.txt


### PR DESCRIPTION
# Description

This PR introduces a .gitignore in the global scope of the mono repo.

The global will eventually have it's own `readme.md`.