### PR TITLE
Adding `yarn.lock` to `.gitignore`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # Package-lock
 package-lock.json
+yarn.lock


### PR DESCRIPTION
### Description

This PR removes `yarn.lock` from git tracking as it has been added to `.gitignore`

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
